### PR TITLE
added validation for photos on the listing

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -3,6 +3,7 @@ class Listing < ApplicationRecord
   has_many :bookings, dependent: :destroy
   has_many :reviews
   has_many_attached :photos
+  validates :photos, presence: true
   validates :name, presence: true
   validates :name, length: { maximum: 50 }
   validates :category, inclusion: { in: ["tuxedo", "black tie", "white tie", "gown", "dress", "heels"] }


### PR DESCRIPTION
now throws an error if a user tries to upload a listing without an image